### PR TITLE
Fix maven resources

### DIFF
--- a/osmotester/pom.xml
+++ b/osmotester/pom.xml
@@ -276,6 +276,21 @@
 					<exclude>**/*.java</exclude>
 				</excludes>
 			</testResource>
+			<testResource>
+				<directory>.</directory>
+				<includes>
+					<include>license.txt</include>
+				</includes>
+			</testResource>
+			<testResource>
+				<directory>test-data1</directory>
+			</testResource>
+			<testResource>
+				<directory>test-data2</directory>
+			</testResource>
+			<testResource>
+				<directory>osmo-output</directory>
+			</testResource>
 		</testResources>
 	</build>
 	<reporting>

--- a/osmotester/test/osmo/common/FileCopyTests.java
+++ b/osmotester/test/osmo/common/FileCopyTests.java
@@ -21,7 +21,7 @@ public class FileCopyTests {
 
   @Test
   public void fileCopy() throws Exception {
-    TestUtils.copyFiles("osmotester/license.txt", targetDir);
+    TestUtils.copyFiles("license.txt", targetDir);
     File file = new File(targetDir+"/license.txt");
     assertTrue("File should be copied", file.exists());
     assertTrue("File should be .. a file!", file.isFile());
@@ -29,7 +29,7 @@ public class FileCopyTests {
 
   @Test
   public void dirCopy() throws Exception {
-    TestUtils.copyFiles("osmotester/test-data1", targetDir);
+    TestUtils.copyFiles("test-data1", targetDir);
     File file = new File(targetDir+"/afile.txt");
     assertTrue("File should be copied", file.exists());
     assertTrue("File should be .. a file!", file.isFile());
@@ -40,7 +40,7 @@ public class FileCopyTests {
 
   @Test
   public void nestedDirCopy() throws Exception {
-    TestUtils.copyFiles("osmotester/test-data2", targetDir);
+    TestUtils.copyFiles("test-data2", targetDir);
     File file = new File(targetDir+"/level1.txt");
     assertTrue("File should be copied", file.exists());
     assertTrue("File should be .. a file!", file.isFile());
@@ -64,9 +64,9 @@ public class FileCopyTests {
 
   @Test
   public void invalidTarget() throws Exception {
-    TestUtils.copyFiles("osmotester/license.txt", targetDir);
+    TestUtils.copyFiles("license.txt", targetDir);
     try {
-      TestUtils.copyFiles("osmotester/license.txt", targetDir+"/license.txt");
+      TestUtils.copyFiles("license.txt", targetDir+"/license.txt");
       fail("Invalid target should fail copy.");
     } catch (IllegalArgumentException e) {
       assertEquals("Msg for invalid source to copy", "Cannot copy to 'test-target-dir/license.txt', target exists and is not a directory.", e.getMessage());

--- a/osmotester/test/osmo/common/UtilTests.java
+++ b/osmotester/test/osmo/common/UtilTests.java
@@ -262,13 +262,13 @@ public class UtilTests {
 
   @Test
   public void listFilesNameOnly() {
-    List<String> files = listFiles("osmotester/test-data2", "txt", false);
+    List<String> files = listFiles("test-data2", "txt", false);
     assertEquals("Files", "[level1.txt]", files.toString());
   }
 
   @Test
   public void listFilesFullPath() {
-    List<String> files = listFiles("osmotester/test-data1", "txt", true);
+    List<String> files = listFiles("test-data1", "txt", true);
     String filename = files.get(0);
     assertTrue("File path should end with file name (afile.txt), was "+filename, filename.endsWith("afile.txt"));
     assertTrue("File should have full path, was "+filename, filename.length() > "afile.txt".length());


### PR DESCRIPTION
Adding the test resources fixed a few tests, as expected.

Here is the result of my last run...
```
Failed tests:
  UtilTests.createLong:104 Generated longs for 11111111112 should be in 30% range (70-130), was:67
  ReducerTests.startTest:158 Reducer report expected:<... sequences:
  [Step4[, Step4]]
  [Step6]
  [Step8...> but was:<... sequences:
  [Step4[]]
  [Step6]
  [Step8...>
  ReportTests.writeSteps:132 Jenkins report for steps expected:<...atorModel" time="0.0[0]">
  </testcase>
  <...> but was:<...atorModel" time="0.0[1]">
  </testcase>
  <...>

Tests in error:
  ListenerTests.failureCollector:145 ▒ Runtime Failed to write to file:osmo-outp...
  ListenerTests.generateTestModel2:83 ▒ Runtime Failed to write to file:osmo-out...
  MultiOSMOTests.errorInTest:90 ▒ Runtime Failed to run a (Multi) OSMOTester

Tests run: 398, Failures: 3, Errors: 3, Skipped: 3
```
`UtilTests` and `ReportTests` only fails sometimes. `ReducerTests`, `ListenerTests`, and `MultiOSMOTests` fail this way consistently. Running `mvn test -Dtest=TESTNAME` is successful for all except the `MultiOSMOTests`. For that one, I had to prevent forking with `mvn test -Dtest=MultiOSMOTests -Dsurefire.forkNumber=0`. The fact that the tests pass when they are run individually suggests test isolation issues.

These changes get us a little closer to a passing maven build but we are not there yet.

By the way, I apologize for the formatting changes in my previous pull request. I will respect the format. We can talk about a way to automate formatting with the `formatter-maven-plugin` after we get the maven build passing.