### PR TITLE
Isolate test folders

### DIFF
--- a/osmotester/test/osmo/tester/unittests/generation/ListenerTests.java
+++ b/osmotester/test/osmo/tester/unittests/generation/ListenerTests.java
@@ -141,10 +141,11 @@ public class ListenerTests {
     List<TestCase> tests = suite.getAllTestCases();
     assertEquals("Number of tests in generator", 0, tests.size());
     assertEquals("Number of collected failures", 7, collector.getFailed().size());
-    TestUtils.recursiveDelete("osmo-output");
-    collector.writeTrace("osmo-output");
+    final String listenerFolder = "osmo-output/listener";
+    TestUtils.recursiveDelete(listenerFolder);
+    collector.writeTrace(listenerFolder);
     TestLoader loader = new TestLoader();
-    List<TestScript> scripts = loader.loadTests("osmo-output");
+    List<TestScript> scripts = loader.loadTests(listenerFolder);
     assertEquals("Number of loaded tests", 7, scripts.size());
   }
 }

--- a/osmotester/test/osmo/tester/unittests/generation/MultiOSMOTests.java
+++ b/osmotester/test/osmo/tester/unittests/generation/MultiOSMOTests.java
@@ -1,5 +1,10 @@
 package osmo.tester.unittests.generation;
 
+import static java.util.Arrays.stream;
+
+import java.io.File;
+
+import org.junit.Before;
 import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -22,6 +27,14 @@ import static org.junit.Assert.*;
 
 /** @author Teemu Kanstren */
 public class MultiOSMOTests {
+  private static final String OUTPUT_FOLDER = "osmo-output";
+
+  @Before
+  public void clearFiles() {
+    final File outputFolder = new File(OUTPUT_FOLDER);
+    stream(outputFolder.listFiles()).forEach(file -> file.delete());
+  }
+
   @After
   public void restore() {
     TestUtils.endOutputCapture();
@@ -29,7 +42,6 @@ public class MultiOSMOTests {
   
   @Test
   public void defaultFactory() {
-    TestUtils.recursiveDelete("osmo-output");
     MultiOSMO mosmo = new MultiOSMO(4);
     TestUtils.startOutputCapture();
     try {
@@ -45,7 +57,6 @@ public class MultiOSMOTests {
   @Test
   public void generate4() throws Exception {
     Thread.sleep(100);
-    TestUtils.recursiveDelete("osmo-output");
     MultiOSMO mosmo = new MultiOSMO(4);
     OSMOConfiguration config = mosmo.getConfig();
     config.setSequenceTraceRequested(true);
@@ -53,18 +64,17 @@ public class MultiOSMOTests {
     config.setTestEndCondition(new Length(10));
     config.setSuiteEndCondition(new Time(2));
     mosmo.generate(new Time(1), 444);
-//    List<String> reports = TestUtils.listFiles("osmo-output", ".csv", false);
+//    List<String> reports = TestUtils.listFiles(OUTPUT_FOLDER, ".csv", false);
 //    assertEquals("Number of reports generated", 4, reports.size());
-    List<String> traces = TestUtils.listFiles("osmo-output", ".html", false);
+    List<String> traces = TestUtils.listFiles(OUTPUT_FOLDER, ".html", false);
     assertEquals("Number of HTML traces generated", 4, traces.size());
-    List<String> xmls = TestUtils.listFiles("osmo-output", ".xml", false);
+    List<String> xmls = TestUtils.listFiles(OUTPUT_FOLDER, ".xml", false);
     assertEquals("Number of XML traces generated", 4, xmls.size());
   }
 
   @Ignore
   @Test
   public void generate4times3() {
-    TestUtils.recursiveDelete("osmo-output");
     MultiOSMO mosmo = new MultiOSMO(4);
     OSMOConfiguration config = mosmo.getConfig();
     config.setSequenceTraceRequested(true);
@@ -72,9 +82,9 @@ public class MultiOSMOTests {
     config.setTestEndCondition(new Length(10));
     config.setSuiteEndCondition(new Time(2));
     mosmo.generate(new Time(6), 444);
-    List<String> reports = TestUtils.listFiles("osmo-output", ".csv", false);
+    List<String> reports = TestUtils.listFiles(OUTPUT_FOLDER, ".csv", false);
     assertEquals("Number of reports generated", 5, reports.size());
-    List<String> traces = TestUtils.listFiles("osmo-output", ".html", false);
+    List<String> traces = TestUtils.listFiles(OUTPUT_FOLDER, ".html", false);
     assertEquals("Number of traces generated", 4, traces.size());
   }
   

--- a/osmotester/test/osmo/tester/unittests/optimizer/ReducerTests.java
+++ b/osmotester/test/osmo/tester/unittests/optimizer/ReducerTests.java
@@ -35,6 +35,8 @@ import static org.junit.Assert.*;
  * @author Teemu Kanstren
  */
 public class ReducerTests {
+  private static final String REDUCER_FOLDER = "osmo-output/reducer-111";
+	
   @Test
   public void nothingFound() throws Exception {
     ReducerConfig config = new ReducerConfig(111);
@@ -56,7 +58,7 @@ public class ReducerTests {
 
   @Test
   public void probableModel() throws Exception {
-    TestUtils.recursiveDelete("osmo-output");
+    TestUtils.recursiveDelete(REDUCER_FOLDER);
     ReducerConfig config = new ReducerConfig(111);
     config.setParallelism(1);
     Reducer reducer = new Reducer(config);
@@ -74,17 +76,18 @@ public class ReducerTests {
     TestCase test1 = tests.get(0);
     assertEquals("Final test length", 1, test1.getAllStepNames().size());
     assertEquals("Iteration lengths", "[]", state.getLengths().toString());
-    String report = TestUtils.readFile("osmo-output/reducer-111/reducer-final.txt", "UTF8");
+    String report = TestUtils.readFile(REDUCER_FOLDER + "/reducer-final.txt", "UTF8");
     String expected = TestUtils.getResource(ReducerTests.class, "expected-reducer.txt");
     report = TestUtils.unifyLineSeparators(report, "\n");
     expected = TestUtils.unifyLineSeparators(expected, "\n");
     assertEquals("Reducer report", expected, report);
-    List<String> files = TestUtils.listFiles("osmo-output/reducer-111", ".html", false);
+    List<String> files = TestUtils.listFiles(REDUCER_FOLDER, ".html", false);
     assertEquals("Generated report files", "[final-tests.html]", files.toString());
   }
 
   @Test
   public void model10() throws Exception {
+    TestUtils.recursiveDelete(REDUCER_FOLDER);
     ReducerConfig config = new ReducerConfig(111);
     config.setStrictReduction(false);
     config.setParallelism(1);
@@ -111,7 +114,7 @@ public class ReducerTests {
     //although it would be possible to have others as well..
     // assertEquals("Final test length", 11, test1.getAllStepNames().size());
     // assertEquals("Iteration lengths", "[25, 22, 17, 14, 13, 12, 11]", state.getLengths().toString());
-    String report = TestUtils.readFile("osmo-output/reducer-111/reducer-final.txt", "UTF8");
+    String report = TestUtils.readFile(REDUCER_FOLDER + "/reducer-final.txt", "UTF8");
     String expected = TestUtils.getResource(ReducerTests.class, "expected-reducer3.txt");
     report = TestUtils.unifyLineSeparators(report, "\n");
     expected = TestUtils.unifyLineSeparators(expected, "\n");
@@ -119,12 +122,13 @@ public class ReducerTests {
     report = replaced[0];
     expected = replaced[1];
     assertEquals("Reducer report", expected, report);
-    List<String> files = TestUtils.listFiles("osmo-output/reducer-111", ".html", false);
+    List<String> files = TestUtils.listFiles(REDUCER_FOLDER, ".html", false);
     assertEquals("Generated report files", "[final-tests.html]", files.toString());
   }
 
   @Test
   public void startTest() throws Exception {
+    TestUtils.recursiveDelete(REDUCER_FOLDER);
     ReducerConfig config = new ReducerConfig(111);
     config.setParallelism(1);
     //changed here on 8apr15
@@ -148,7 +152,7 @@ public class ReducerTests {
     ReducerState state = reducer.search();
     List<TestCase> tests = state.getTests();
     TestCase test1 = tests.get(0);
-    String report = TestUtils.readFile("osmo-output/reducer-111/reducer-final.txt", "UTF8");
+    String report = TestUtils.readFile(REDUCER_FOLDER + "/reducer-final.txt", "UTF8");
     String expected = TestUtils.getResource(ReducerTests.class, "expected-reducer4.txt");
     report = TestUtils.unifyLineSeparators(report, "\n");
     expected = TestUtils.unifyLineSeparators(expected, "\n");
@@ -156,7 +160,7 @@ public class ReducerTests {
     report = replaced[0];
     expected = replaced[1];
     assertEquals("Reducer report", expected, report);
-    List<String> files = TestUtils.listFiles("osmo-output/reducer-111", ".html", false);
+    List<String> files = TestUtils.listFiles(REDUCER_FOLDER, ".html", false);
     assertEquals("Generated report files", "[final-tests.html]", files.toString());
   }
 


### PR DESCRIPTION
The first commit (0eb4fb2) got me down to one failure consistently, `ReducerTests`. Running the test alone passes. I added the other commits to ensure the tests did not get in anyone's way.

I like your idea of comparing objects instead of files. I also recommend using [AssertJ](http://joel-costigliola.github.io/assertj/) to make assertions more readable. Would you mind if I introduced it when I find the need to change an assertion?

To answer your question about my OS, I am running Windows 10 on an Intel(R) Core(TM) i7-4500U CPU @ 1.80GHz, 2401 Mhz, 2 Core(s), 4 Logical Processors.